### PR TITLE
Log m2m relations

### DIFF
--- a/simple_audit/models.py
+++ b/simple_audit/models.py
@@ -76,8 +76,8 @@ class Audit(models.Model):
 class AuditChange(models.Model):
     audit = models.ForeignKey(Audit, related_name='field_changes')
     field = models.CharField(max_length=255)
-    old_value = models.TextField()
-    new_value = models.TextField()
+    old_value = models.TextField(null=True, blank=True)
+    new_value = models.TextField(null=True, blank=True)
 
     class Meta:
         db_table = 'audit_change'

--- a/simple_audit/settings.py
+++ b/simple_audit/settings.py
@@ -6,6 +6,7 @@ LOG = logging.getLogger(__name__)
 
 DJANGO_SIMPLE_AUDIT_ACTIVATED = getattr(settings, 'DJANGO_SIMPLE_AUDIT_ACTIVATED', False)
 DJANGO_SIMPLE_AUDIT_M2M_FIELDS = getattr(settings, 'DJANGO_SIMPLE_AUDIT_M2M_FIELDS', False)
+DJANGO_SIMPLE_AUDIT_M2M_RELATIONS = getattr(settings, 'DJANGO_SIMPLE_AUDIT_M2M_RELATIONS', False)
 
 if not hasattr(settings, 'CACHES'):
     LOG.warning("no cache backend set in django! m2m auditing will be disabled")

--- a/simple_audit/settings.py
+++ b/simple_audit/settings.py
@@ -1,6 +1,7 @@
 """Settings for django-simple-audit"""
 import logging
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 LOG = logging.getLogger(__name__)
 
@@ -11,3 +12,6 @@ DJANGO_SIMPLE_AUDIT_M2M_RELATIONS = getattr(settings, 'DJANGO_SIMPLE_AUDIT_M2M_R
 if not hasattr(settings, 'CACHES'):
     LOG.warning("no cache backend set in django! m2m auditing will be disabled")
     DJANGO_SIMPLE_AUDIT_M2M_FIELDS = False
+
+if DJANGO_SIMPLE_AUDIT_M2M_FIELDS and DJANGO_SIMPLE_AUDIT_M2M_RELATIONS:
+    raise ImproperlyConfigured("You cannot audit both M2M field changes and relations - choose one or the other")

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -55,16 +55,7 @@ def audit_m2m_change_relation(sender, **kwargs):
     if kwargs.get('action'):
         action = kwargs.get('action')
         instance = kwargs.get('instance')
-        if kwargs['action'] == "pre_remove":
-            import ipdb; ipdb.set_trace()
-            print 'pre_remove'
-            pass
-        elif kwargs['action'] == "post_remove":
-            print 'post_remove'
-            pass
-        elif kwargs['action'] == 'pre_add':
-            pass
-        elif kwargs['action'] == 'post_add':
+        if kwargs['action'] == 'post_add':
             cache_key = get_cache_key_for_instance(instance)
             dict_ = cache.get(cache_key)
             if not dict_:

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -73,7 +73,6 @@ def audit_m2m_change_relation(sender, **kwargs):
             dict_["old_state"] = m2m_audit.get_m2m_values_for(instance=instance)
             for k,v in dict_['old_state'].items():
                 dict_['old_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
-            import ipdb; ipdb.set_trace()
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
             LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
         elif kwargs['action'] == 'post_clear':

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -73,8 +73,6 @@ def audit_m2m_change_relation(sender, **kwargs):
                 dict_['old_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
             LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
-        elif kwargs['action'] == 'post_clear':
-            print 'post_clear'
 
 def audit_post_save(sender, **kwargs):
     if kwargs['created'] and not kwargs.get('raw', False):

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -99,13 +99,9 @@ def audit_pre_save(sender, **kwargs):
     if instance.pk and not kwargs.get('raw', False):
         if settings.DJANGO_SIMPLE_AUDIT_M2M_FIELDS or settings.DJANGO_SIMPLE_AUDIT_M2M_RELATIONS:
             if m2m_audit.get_m2m_fields_for(instance): #has m2m fields?
-                import ipdb; ipdb.set_trace()
                 cache_key = get_cache_key_for_instance(instance)
-                dict_ = {"old_state" : {}, "new_state": {}, "old_state_m2m": {}, "new_state_m2m": {}}
+                dict_ = {"old_state" : {}, "new_state": {}}
                 dict_["old_state"] = m2m_audit.get_m2m_values_for(instance=instance)
-                for k,v in dict_['old_state'].items():
-                    dict_['old_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
-                import ipdb; ipdb.set_trace()
                 cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
                 LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
         save_audit(kwargs['instance'], Audit.CHANGE)

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -289,7 +289,9 @@ def save_audit(instance, operation, kwargs={}):
             repr(instance), type(instance), getattr(instance, '__dict__', None), exc_info=True)
 
 
-def handle_unicode(s):
-    if isinstance(s, basestring):
-        return s.encode('utf-8')
-    return s
+def handle_unicode(val):
+    if not val:
+        return None
+    elif isinstance(val, basestring):
+        return val.encode('utf-8')
+    return val

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -235,8 +235,8 @@ def save_audit(instance, operation, kwargs={}):
                         change = AuditChange()
                         change.audit = audit
                         change.field = field
-                        change.new_value = new_value
-                        change.old_value = old_value
+                        change.new_value = handle_unicode(new_value)
+                        change.old_value = handle_unicode(old_value)
                         change.save()
             else:
                 audit = Audit.register(instance, description, operation)
@@ -245,9 +245,15 @@ def save_audit(instance, operation, kwargs={}):
                     change = AuditChange()
                     change.audit = audit
                     change.field = field
-                    change.new_value = str(new_value or '')
-                    change.old_value = str(old_value or '')
+                    change.new_value = handle_unicode(new_value)
+                    change.old_value = handle_unicode(old_value)
                     change.save()
     except:
         LOG.error(u'Error registering auditing to %s: (%s) %s',
             repr(instance), type(instance), getattr(instance, '__dict__', None), exc_info=True)
+
+
+def handle_unicode(s):
+    if isinstance(s, basestring):
+        return s.encode('utf-8')
+    return s

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -26,9 +26,7 @@ def audit_m2m_change(sender, **kwargs):
     if kwargs.get('action'):
         action = kwargs.get('action')
         instance = kwargs.get('instance')
-        if kwargs['action'] == "pre_add":
-            pass
-        elif kwargs['action'] == "post_add":
+        if kwargs['action'] == "post_add":
             cache_key = get_cache_key_for_instance(instance)
             dict_ = cache.get(cache_key)
             if not dict_:
@@ -38,14 +36,8 @@ def audit_m2m_change(sender, **kwargs):
             dict_["m2m_change"] = True
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
             save_audit(instance, Audit.CHANGE, kwargs=dict_)
-        elif kwargs['action'] == "pre_remove":
-            pass
         elif kwargs['action'] == "post_remove":
             save_audit(kwargs['instance'], Audit.DELETE, kwargs=kwargs)
-        elif kwargs['action'] == "pre_clear":
-            pass
-        elif kwargs['action'] == "post_clear":
-            pass
 
 
 def audit_m2m_change_relation(sender, **kwargs):

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -55,7 +55,7 @@ def audit_m2m_change_relation(sender, **kwargs):
     if kwargs.get('action'):
         action = kwargs.get('action')
         instance = kwargs.get('instance')
-        if kwargs['action'] == 'post_add':
+        if kwargs['action'] in {'post_add', 'post_clear'}:
             cache_key = get_cache_key_for_instance(instance)
             dict_ = cache.get(cache_key)
             if not dict_:

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -75,7 +75,7 @@ def audit_pre_save(sender, **kwargs):
     instance=kwargs.get('instance')
 
     if instance.pk and not kwargs.get('raw', False):
-        if settings.DJANGO_SIMPLE_AUDIT_M2M_FIELDS or settings.DJANGO_SIMPLE_AUDIT_M2M_RELATIONS:
+        if settings.DJANGO_SIMPLE_AUDIT_M2M_FIELDS:
             if m2m_audit.get_m2m_fields_for(instance): #has m2m fields?
                 cache_key = get_cache_key_for_instance(instance)
                 dict_ = {"old_state" : {}, "new_state": {}}

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -63,10 +63,8 @@ def audit_m2m_change_relation(sender, **kwargs):
             dict_["new_state"] = m2m_audit.get_m2m_values_for(instance=instance)
             for k,v in dict_['new_state'].items():
                 dict_['new_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
-            import ipdb; ipdb.set_trace()
-            dict_["m2m_change"] = True
-            cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
-            #save_audit(instance, Audit.CHANGE, kwargs=dict_)
+            dict_["m2m_change_relation"] = True
+            save_audit(instance, Audit.CHANGE, kwargs=dict_)
         elif kwargs['action'] == 'pre_clear':
             cache_key = get_cache_key_for_instance(instance)
             dict_ = {"old_state" : {}, "new_state": {}, "old_state_m2m": {}, "new_state_m2m": {}}

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -51,18 +51,18 @@ def audit_m2m_change_relation(sender, **kwargs):
             cache_key = get_cache_key_for_instance(instance)
             dict_ = cache.get(cache_key)
             if not dict_:
-                dict_ = {"old_state" : {}, "new_state": {}, "old_state_m2m": {}, "new_state_m2m": {}}
             dict_["new_state"] = m2m_audit.get_m2m_values_for(instance=instance)
             for k,v in dict_['new_state'].items():
                 dict_['new_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
+                dict_ = {"old_state_m2m": {}, "new_state_m2m": {}}
             dict_["m2m_change_relation"] = True
             save_audit(instance, Audit.CHANGE, kwargs=dict_)
         elif kwargs['action'] == 'pre_clear':
             cache_key = get_cache_key_for_instance(instance)
-            dict_ = {"old_state" : {}, "new_state": {}, "old_state_m2m": {}, "new_state_m2m": {}}
             dict_["old_state"] = m2m_audit.get_m2m_values_for(instance=instance)
             for k,v in dict_['old_state'].items():
                 dict_['old_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
+            dict_ = {"old_state_m2m": {}, "new_state_m2m": {}}
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
             LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
 

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -51,18 +51,18 @@ def audit_m2m_change_relation(sender, **kwargs):
             cache_key = get_cache_key_for_instance(instance)
             dict_ = cache.get(cache_key)
             if not dict_:
-            dict_["new_state"] = m2m_audit.get_m2m_values_for(instance=instance)
-            for k,v in dict_['new_state'].items():
-                dict_['new_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
                 dict_ = {"old_state_m2m": {}, "new_state_m2m": {}}
+            new_m2ms = m2m_audit.get_m2m_values_for(instance=instance)
+            for k,v in new_m2ms.items():
+                dict_['new_state_m2m'][k] = [item['id'] for item in v]
             dict_["m2m_change_relation"] = True
             save_audit(instance, Audit.CHANGE, kwargs=dict_)
         elif kwargs['action'] == 'pre_clear':
             cache_key = get_cache_key_for_instance(instance)
-            dict_["old_state"] = m2m_audit.get_m2m_values_for(instance=instance)
-            for k,v in dict_['old_state'].items():
-                dict_['old_state_m2m'][k] = [item['id'] for item in v]  # eg {'followers': [1,2,3]}
             dict_ = {"old_state_m2m": {}, "new_state_m2m": {}}
+            old_m2ms = m2m_audit.get_m2m_values_for(instance=instance)
+            for k,v in old_m2ms.items():
+                dict_['old_state_m2m'][k] = [item['id'] for item in v]
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
             LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
 

--- a/simple_audit/signal.py
+++ b/simple_audit/signal.py
@@ -64,7 +64,7 @@ def audit_m2m_change_relation(sender, **kwargs):
             for k,v in old_m2ms.items():
                 dict_['old_state_m2m'][k] = [item['id'] for item in v]
             cache.set(cache_key, dict_, DEFAULT_CACHE_TIMEOUT)
-            LOG.debug("old_state saved in cache with key %s for m2m auditing" % cache_key)
+            LOG.debug("old_state saved in cache with key %s for m2m relation auditing" % cache_key)
 
 def audit_post_save(sender, **kwargs):
     if kwargs['created'] and not kwargs.get('raw', False):


### PR DESCRIPTION
Not ready
- When logging M2M relations, don't audit M2M field changes. Simply log the relation change (e.g. pk's added or removed). This feature should be configurable
